### PR TITLE
fix error item price harus bilangan bulat

### DIFF
--- a/request.go
+++ b/request.go
@@ -4,7 +4,7 @@ package midtrans
 type ItemDetail struct {
     Id string `json:"id"`
     Name string `json:"name"`
-    Price float64 `json:"price"`
+    Price int64 `json:"price"`
     Qty int32 `json:"quantity"`
 }
 
@@ -34,7 +34,7 @@ type CustDetail struct {
 
 type TransactionDetails struct {
     OrderID string `json:"order_id"`
-    GrossAmt float64 `json:"gross_amount"`
+    GrossAmt int64 `json:"gross_amount"`
 }
 
 type CreditCardDetail struct {

--- a/snap.go
+++ b/snap.go
@@ -21,7 +21,7 @@ func (gway *SnapGateway) Call(method, path string, body io.Reader, v interface{}
 }
 
 // Quickly get token without constructing the body manually
-func (g *SnapGateway) GetTokenQuick(orderId string, gross_amount float64) (SnapResponse, error) {
+func (g *SnapGateway) GetTokenQuick(orderId string, gross_amount int64) (SnapResponse, error) {
     return g.GetToken(&SnapReq{
         TransactionDetails: TransactionDetails{
             OrderID: orderId,


### PR DESCRIPTION
Golang will marshal json the struct of float to something like 1.5e6 instead of 1500000.