### PR TITLE
Add some request and response fields

### DIFF
--- a/request.go
+++ b/request.go
@@ -2,10 +2,10 @@ package midtrans
 
 // Represent the transaction details
 type ItemDetail struct {
-    Id string `json:"id"`
-    Name string `json:"name"`
-    Price int64 `json:"price"`
-    Qty int32 `json:"quantity"`
+	Id    string `json:"id"`
+	Name  string `json:"name"`
+	Price int64  `json:"price"`
+	Qty   int32  `json:"quantity"`
 }
 
 type CustAddress struct {
@@ -33,8 +33,8 @@ type CustDetail struct {
 }
 
 type TransactionDetails struct {
-    OrderID string `json:"order_id"`
-    GrossAmt int64 `json:"gross_amount"`
+	OrderID  string `json:"order_id"`
+	GrossAmt int64  `json:"gross_amount"`
 }
 
 type CreditCardDetail struct {
@@ -167,9 +167,12 @@ type SnapReq struct {
 	EnabledPayments    []PaymentType      `json:"enabled_payments"`
 	Items              *[]ItemDetail      `json:"item_details,omitempty"`
 	CustomerDetail     *CustDetail        `json:"customer_details,omitempty"`
+	CustomField1       string             `json:"custom_field1"`
+	CustomField2       string             `json:"custom_field2"`
+	CustomField3       string             `json:"custom_field3"`
 }
 
 type CaptureReq struct {
-    TransactionID string `json:"transaction_id"`
-    GrossAmt float64 `json:"gross_amount"`
+	TransactionID string  `json:"transaction_id"`
+	GrossAmt      float64 `json:"gross_amount"`
 }

--- a/response.go
+++ b/response.go
@@ -39,5 +39,6 @@ type Response struct {
 type SnapResponse struct {
 	StatusCode    string   `json:"status_code"`
 	Token         string   `json:"token"`
+	RedirectURL   string   `json:"redirect_url"`
 	ErrorMessages []string `json:"error_messages"`
 }


### PR DESCRIPTION
Currently Snap also returns `redirect_url` too when creating snap token

Here is the sample response:

```json
{
    "token": "SNAP_TOKEN",
    "redirect_url": "SNAP_WEB_URL"
}
```

Also based on snap-docs.midtrans.com, Snap request also supports `custom_field1`, `custom_field2` and `custom_field3` .