### PR TITLE
ADD fraud status and payment type, come on midtrans!

### DIFF
--- a/request.go
+++ b/request.go
@@ -38,6 +38,7 @@ type TransactionDetails struct {
 }
 
 type CreditCardDetail struct {
+	Secure          bool     `json:"secure"`
 	TokenID         string   `json:"token_id"`
 	Bank            string   `json:"bank,omitempty"`
 	Bins            []string `json:"bins,omitempty"`

--- a/request.go
+++ b/request.go
@@ -38,7 +38,7 @@ type TransactionDetails struct {
 }
 
 type CreditCardDetail struct {
-	Secure          bool     `json:"secure"`
+	Secure          bool     `json:"secure,omitempty"`
 	TokenID         string   `json:"token_id"`
 	Bank            string   `json:"bank,omitempty"`
 	Bins            []string `json:"bins,omitempty"`

--- a/request.go
+++ b/request.go
@@ -168,6 +168,7 @@ type SnapReq struct {
 	EnabledPayments    []PaymentType      `json:"enabled_payments"`
 	Items              *[]ItemDetail      `json:"item_details,omitempty"`
 	CustomerDetail     *CustDetail        `json:"customer_details,omitempty"`
+	CreditCard         *CreditCardDetail  `json:"credit_card,omitempty"`
 	CustomField1       string             `json:"custom_field1"`
 	CustomField2       string             `json:"custom_field2"`
 	CustomField3       string             `json:"custom_field3"`

--- a/response.go
+++ b/response.go
@@ -26,6 +26,8 @@ type Response struct {
 	Page              int        `json:"page"`
 	TotalPage         int        `json:"total_page"`
 	TotalRecord       int        `json:"total_record"`
+	FraudStatus       string     `json:"fraud_status"`
+	PaymentType       string     `json:"payment_type"`
 	OrderID           string     `json:"order_id"`
 	TransactionId     string     `json:"transaction_id"`
 	TransactionTime   string     `json:"transaction_time"`


### PR DESCRIPTION
- `Fraud Status` is required to check wether any credit card transaction was rejected or has any fraud detected.
- `Payment Type` needed to re-map midtrans transaction with local transaction.

Come on midtrans!