### PR TITLE
Modify paysource

### DIFF
--- a/paysource.go
+++ b/paysource.go
@@ -13,9 +13,6 @@ const (
 	// SourceBCAVA : bca_va
 	SourceBCAVA PaymentType = "bca_va"
 
-	// SourceBbmMoney : bbm_money
-	SourceBbmMoney PaymentType = "bbm_money"
-
 	// SourceBcaKlikpay : bca_klikpay
 	SourceBcaKlikpay PaymentType = "bca_klikpay"
 
@@ -45,9 +42,6 @@ const (
 
 	// SourceTelkomselCash : telkomsel_cash
 	SourceTelkomselCash PaymentType = "telkomsel_cash"
-
-	// SourceXlTunai : xl_tunai
-	SourceXlTunai PaymentType = "xl_tunai"
 
 	// SourceIndosatDompetku : indosat_dompetku
 	SourceIndosatDompetku PaymentType = "indosat_dompetku"
@@ -80,8 +74,6 @@ var AllPaymentSource = []PaymentType{
 	SourceBriEpay,
 	SourceTelkomselCash,
 	SourceEchannel,
-	SourceBbmMoney,
-	SourceXlTunai,
 	SourceIndosatDompetku,
 	SourceMandiriEcash,
 	SourcePermataVA,

--- a/paysource.go
+++ b/paysource.go
@@ -4,9 +4,6 @@ package midtrans
 type PaymentType string
 
 const (
-	// SourceBankTransfer : gopay
-	SourceGopay PaymentType = "gopay"
-
 	// SourceBankTransfer : bank_transfer
 	SourceBankTransfer PaymentType = "bank_transfer"
 
@@ -30,6 +27,9 @@ const (
 
 	// SourceCimbClicks : cimb_clicks
 	SourceCimbClicks PaymentType = "cimb_clicks"
+
+	// SourceDanamonOnline : danamon_online
+	SourceDanamonOnline PaymentType = "danamon_online"
 
 	// SourceConvStore : cstore
 	SourceConvStore PaymentType = "cstore"
@@ -63,6 +63,9 @@ const (
 
 	// SourceGiftCardIndo : gci
 	SourceGiftCardIndo PaymentType = "gci"
+
+	// SourceGopay : gopay
+	SourceGopay PaymentType = "gopay"
 )
 
 // AllPaymentSource : Get All available PaymentType
@@ -71,6 +74,7 @@ var AllPaymentSource = []PaymentType{
 	SourceCreditCard,
 	SourceMandiriClickpay,
 	SourceCimbClicks,
+	SourceDanamonOnline,
 	SourceKlikBca,
 	SourceBcaKlikpay,
 	SourceBriEpay,

--- a/paysource_test.go
+++ b/paysource_test.go
@@ -12,6 +12,7 @@ func TestPaymentType(t *testing.T) {
 	is.Equal("credit_card", midtrans.SourceCreditCard)
 	is.Equal("bank_transfer", midtrans.SourceBankTransfer)
 	is.Equal("cimb_clicks", midtrans.SourceCimbClicks)
+	is.Equal("danamon_online", midtrans.SourceDanamonOnline)
 	is.Equal("mandiri_clickpay", midtrans.SourceMandiriClickpay)
 	is.Equal("bri_epay", midtrans.SourceBriEpay)
 	is.Equal("telkomsel_cash", midtrans.SourceTelkomselCash)
@@ -19,4 +20,5 @@ func TestPaymentType(t *testing.T) {
 	is.Equal("cstore", midtrans.SourceConvStore)
 	is.Equal("bca_klikbca", midtrans.SourceKlikBca)
 	is.Equal("bca_klikpay", midtrans.SourceBcaKlikpay)
+	is.Equal("gopay", midtrans.SourceGopay)
 }

--- a/paysource_test.go
+++ b/paysource_test.go
@@ -15,8 +15,6 @@ func TestPaymentType(t *testing.T) {
 	is.Equal("mandiri_clickpay", midtrans.SourceMandiriClickpay)
 	is.Equal("bri_epay", midtrans.SourceBriEpay)
 	is.Equal("telkomsel_cash", midtrans.SourceTelkomselCash)
-	is.Equal("xl_tunai", midtrans.SourceXlTunai)
-	is.Equal("bbm_money", midtrans.SourceBbmMoney)
 	is.Equal("echannel", midtrans.SourceEchannel)
 	is.Equal("cstore", midtrans.SourceConvStore)
 	is.Equal("bca_klikbca", midtrans.SourceKlikBca)

--- a/response.go
+++ b/response.go
@@ -6,6 +6,7 @@ type VANumber struct {
 	VANumber string `json:"va_number"`
 }
 
+// Action represents response action
 type Action struct {
 	Name   string `json:"name"`
 	Method string `json:"method"`


### PR DESCRIPTION
Hi @rizdaprasetya and Midtrans team!

Based on Snap API official documents, I proposed to add `danamon_online` and remove `xl_tunai` and `bbm_money` on `paysource`. Please take a look. 

Thanks,
Harits Fahreza