### PR TITLE
Omitempty for key in customer detail

### DIFF
--- a/request.go
+++ b/request.go
@@ -22,13 +22,13 @@ type CustAddress struct {
 // CustDetail : Represent the customer detail
 type CustDetail struct {
 	// first name
-	FName string `json:"first_name"`
+	FName string `json:"first_name,omitempty"`
 
 	// last name
-	LName string `json:"last_name"`
+	LName string `json:"last_name,omitempty"`
 
-	Email    string       `json:"email"`
-	Phone    string       `json:"phone"`
+	Email    string       `json:"email,omitempty"`
+	Phone    string       `json:"phone,omitempty"`
 	BillAddr *CustAddress `json:"billing_address,omitempty"`
 	ShipAddr *CustAddress `json:"customer_address,omitempty"`
 }


### PR DESCRIPTION
Set `omitempty` in charge request to prevent set as empty string `""` and make charge request failed.