### PR TITLE
create payout API

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,7 +111,9 @@ func (c *Client) ExecuteRequest(req *http.Request, v interface{}) error {
 
 		// we're safe to reflect status_code if response not an array
 		if reflect.ValueOf(v).Elem().Kind() != reflect.Slice {
-			reflect.ValueOf(v).Elem().FieldByName("StatusCode").SetString(strconv.Itoa(res.StatusCode))
+			if reflect.ValueOf(v).Elem().FieldByName("StatusCode").IsValid() {
+				reflect.ValueOf(v).Elem().FieldByName("StatusCode").SetString(strconv.Itoa(res.StatusCode))
+			}
 		}
 	}
 

--- a/iris.go
+++ b/iris.go
@@ -87,3 +87,21 @@ func (gateway *IrisGateway) GetListBeneficiaries() ([]IrisBeneficiaries, error) 
 
 	return resp, nil
 }
+
+// CreatePayouts : This API is for Creator to create a payout. It can be used for single payout and also multiple payouts. (https://iris-docs.midtrans.com/#create-payouts)
+func (gateway *IrisGateway) CreatePayouts(req IrisCreatePayoutReq) (IrisCreatePayoutResponse, error) {
+	resp := IrisCreatePayoutResponse{}
+	jsonReq, _ := json.Marshal(req)
+
+	err := gateway.Call("POST", "api/v1/payouts", bytes.NewBuffer(jsonReq), &resp)
+	if err != nil {
+		gateway.Client.Logger.Println("Error creating payouts: ", err)
+		return resp, err
+	}
+
+	if resp.ErrorMessage != "" {
+		return resp, errors.New(resp.ErrorMessage)
+	}
+
+	return resp, nil
+}

--- a/request.go
+++ b/request.go
@@ -216,3 +216,17 @@ type CaptureReq struct {
 	TransactionID string  `json:"transaction_id"`
 	GrossAmt      float64 `json:"gross_amount"`
 }
+
+// IrisCreatePayoutReq : Represent Create Payout request payload
+type IrisCreatePayoutReq struct {
+	Payouts []IrisCreatePayoutDetailReq `json:"payouts"`
+}
+
+type IrisCreatePayoutDetailReq struct {
+	BeneficiaryName    string `json:"beneficiary_name"`
+	BeneficiaryAccount string `json:"beneficiary_account"`
+	BeneficiaryBank    string `json:"beneficiary_bank"`
+	BeneficiaryEmail   string `json:"beneficiary_email"`
+	Amount             string `json:"amount"`
+	Notes              string `json:"notes"`
+}

--- a/response.go
+++ b/response.go
@@ -85,3 +85,15 @@ type IrisBeneficiariesResponse struct {
 	StatusCode string   `json:"status_code"`
 	Errors     []string `json:"errors"`
 }
+
+// IrisCreatePayoutResponse : Represent Create Payout response
+type IrisCreatePayoutResponse struct {
+	Payouts      []IrisCreatePayoutDetailResponse `json:"payouts"`
+	ErrorMessage string                           `json:"error_message"`
+	Errors       []string                         `json:"errors"`
+}
+
+type IrisCreatePayoutDetailResponse struct {
+	Status      string `json:"status"`
+	ReferenceNo string `json:"reference_no"`
+}


### PR DESCRIPTION
Exmple code
 
```go
        // create payout
        irisCreatorKey := "IRIS-XXXX"
	midclient := midtrans.NewClient()
	midclient.ServerKey = irisCreatorKey
	midclient.APIEnvType = midtrans.Sandbox
	midclient.LogLevel = 3

	var irisGateway midtrans.IrisGateway
	irisGateway = midtrans.IrisGateway{
		Client: midclient,
	}

	var payouts = midtrans.IrisCreatePayoutReq{
		Payouts: []midtrans.IrisCreatePayoutDetailReq{
			{
				Amount:             "100000",
				BeneficiaryAccount: "3345278421",
				BeneficiaryBank:    "bca",
				BeneficiaryEmail:   "beneficiary@example.com",
				BeneficiaryName:    "John Doe",
				Notes:              "Payout 1",
			},
		},
	}
	payoutRes, err := irisGateway.CreatePayouts(payouts)
	fmt.Println("err CreatePayouts ", payoutRes)
	fmt.Println("err CreatePayouts ", err)
```

success example

```
{[{queued 2b7f4596aef27645b6}]}
```

error example
```
An error occurred when creating payouts
```