### PR TITLE
add store and merchant_id fields to Response struct

### DIFF
--- a/response.go
+++ b/response.go
@@ -46,6 +46,7 @@ type Response struct {
 	VANumbers         []VANumber `json:"va_numbers"`
 	PaymentCode       string     `json:"payment_code"`
 	Store             string     `json:"store"`
+	MerchantID        string     `json:"merchant_id"`
 	MaskedCard        string     `json:"masked_card"`
 	Currency          string     `json:"currency"`
 	CardType          string     `json:"card_type"`

--- a/response.go
+++ b/response.go
@@ -45,6 +45,7 @@ type Response struct {
 	GrossAmount       string     `json:"gross_amount"`
 	VANumbers         []VANumber `json:"va_numbers"`
 	PaymentCode       string     `json:"payment_code"`
+	Store             string     `json:"store"`
 	MaskedCard        string     `json:"masked_card"`
 	Currency          string     `json:"currency"`
 	CardType          string     `json:"card_type"`


### PR DESCRIPTION
add `store` and `merchant_id` field to provide response with `payment_type` alfamart / indomaret

https://api-docs.midtrans.com/#indomaret
https://api-docs.midtrans.com/#alfamart

and based on notification

```
{
  "transaction_time": "2019-11-14 11:47:04",
  "transaction_status": "expire",
  "transaction_id": "xxxx",
  "store": "alfamart",
  "status_message": "midtrans payment notification",
  "status_code": "202",
  "signature_key": "xxx",
  "payment_type": "cstore",
  "payment_code": "xxx",
  "order_id": "xxx",
  "merchant_id": "M105125",
  "gross_amount": "125000.00",
  "fraud_status": "accept",
  "custom_field1": "000002639",
  "currency": "IDR"
}
```