### PR TITLE
Add omitempty on UserId

### DIFF
--- a/request.go
+++ b/request.go
@@ -233,7 +233,7 @@ type SnapReq struct {
 	Expiry             *ExpiryDetail      `json:"expiry,omitempty"`
 	CreditCard         *CreditCardDetail  `json:"credit_card,omitempty"`
 	Gopay              *GopayDetail       `json:"gopay,omitempty"`
-	UserId             string             `json:"user_id"`
+	UserId             string             `json:"user_id,omitempty"`
 	CustomField1       string             `json:"custom_field1"`
 	CustomField2       string             `json:"custom_field2"`
 	CustomField3       string             `json:"custom_field3"`


### PR DESCRIPTION
Adding omitempty on UserId so that the simplepay example using SnapGateway.GetTokenQuick can run

Before adding omitempty:
![image](https://user-images.githubusercontent.com/9023776/99566238-3656f580-29ff-11eb-8712-eb6c75b07646.png)


After adding omitempty:
![image](https://user-images.githubusercontent.com/9023776/99566154-1aebea80-29ff-11eb-9775-9783d10845fa.png)
