### PR TITLE
fix missing omitempty on snap optional params

### DIFF
--- a/request.go
+++ b/request.go
@@ -226,7 +226,7 @@ type ChargeReqWithMap map[string]interface{}
 // SnapReq : Represent SNAP API request payload
 type SnapReq struct {
 	TransactionDetails TransactionDetails `json:"transaction_details"`
-	EnabledPayments    []PaymentType      `json:"enabled_payments"`
+	EnabledPayments    []PaymentType      `json:"enabled_payments,omitempty"`
 	Callbacks          *Callbacks         `json:"callbacks"`
 	Items              *[]ItemDetail      `json:"item_details,omitempty"`
 	CustomerDetail     *CustDetail        `json:"customer_details,omitempty"`
@@ -234,9 +234,9 @@ type SnapReq struct {
 	CreditCard         *CreditCardDetail  `json:"credit_card,omitempty"`
 	Gopay              *GopayDetail       `json:"gopay,omitempty"`
 	UserId             string             `json:"user_id,omitempty"`
-	CustomField1       string             `json:"custom_field1"`
-	CustomField2       string             `json:"custom_field2"`
-	CustomField3       string             `json:"custom_field3"`
+	CustomField1       string             `json:"custom_field1,omitempty"`
+	CustomField2       string             `json:"custom_field2,omitempty"`
+	CustomField3       string             `json:"custom_field3,omitempty"`
 }
 
 type Callbacks struct {


### PR DESCRIPTION
Fix: Bunch of optional params didn't have omitempty on it, which might force user to put in optional params.